### PR TITLE
Fix placeholders in create_from_user_input

### DIFF
--- a/core/german_card.py
+++ b/core/german_card.py
@@ -89,8 +89,8 @@ class GermanCard(AudioCard):
 
     @classmethod
     def create_from_user_input(cls, term, audio_path):
-        card = cls(term, "Example context for {term}", audio_path)
-        card.sentence = "Example sentence with {term}"
-        card.term_translation = "Translation of {term}"
-        card.sentence_translation = "Translation of example sentence with {term}"
+        card = cls(term, f"Example context for {term}", audio_path)
+        card.sentence = f"Example sentence with {term}"
+        card.term_translation = f"Translation of {term}"
+        card.sentence_translation = f"Translation of example sentence with {term}"
         return card

--- a/tests/test_german_card.py
+++ b/tests/test_german_card.py
@@ -68,6 +68,14 @@ def test_gen_id():
         card = GermanCard(term=term, context="Test", audio_path="")
         assert card._id == expected_id, f"Failed for term: '{term}', expected: '{expected_id}', got: '{card._id}'"
 
+def test_create_from_user_input():
+    card = GermanCard.create_from_user_input("Hund", "bark.mp3")
+    assert card.term == "Hund"
+    assert card.context == "Example context for Hund"
+    assert card.sentence == "Example sentence with Hund"
+    assert card.term_translation == "Translation of Hund"
+    assert card.sentence_translation == "Translation of example sentence with Hund"
+
 if __name__ == "__main__":
     test_german_card_creation()
     test_german_card_invalid()


### PR DESCRIPTION
## Summary
- fix missing f-strings in `GermanCard.create_from_user_input`
- add regression test for `create_from_user_input`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68662bb0a2fc83279d9b06aafbeea01a