### PR TITLE
Implement OpenAI vocab provider and tests

### DIFF
--- a/core/german_card.py
+++ b/core/german_card.py
@@ -88,11 +88,15 @@ class GermanCard(AudioCard):
         ]
 
     @classmethod
-    def create_from_user_input(cls, term, context, audio_path, vocab_provider):
-        # TODO: use vocab provider to generate card
+    def create_from_user_input(
+        cls, term: str, context: str, audio_path: str, vocab_provider
+    ):
+        """Create a card using vocabulary data from ``vocab_provider``."""
 
-        card = cls(term, f"Example context for {term}", audio_path)
-        card.sentence = f"Example sentence with {term}"
-        card.term_translation = f"Translation of {term}"
-        card.sentence_translation = f"Translation of example sentence with {term}"
+        data = vocab_provider.get_vocab(term, context)
+
+        card = cls(data.get("term", term), context, audio_path)
+        card.sentence = data.get("sentence", "")
+        card.term_translation = data.get("term_translation", "")
+        card.sentence_translation = data.get("sentence_translation", "")
         return card

--- a/core/vocab_provider.py
+++ b/core/vocab_provider.py
@@ -1,3 +1,101 @@
-# TODO: open AI integration goes here
-# TODO: use ../prompts/*
-# TODO: init with openai api key and target language
+"""Utilities for retrieving vocabulary data from OpenAI.
+
+This module defines :class:`VocabProvider` which wraps a ChatGPT style API call
+and returns structured JSON describing the requested vocabulary term.  The class
+loads prompt templates from the ``prompts`` directory located at the project
+root.  For ease of testing an ``openai_client`` can be injected, so unit tests do
+not depend on the real OpenAI package or network access.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from string import Template
+from typing import Any, Dict, Optional
+
+
+class VocabProvider:
+    """Retrieve vocabulary data using OpenAI chat completion."""
+
+    def __init__(
+        self,
+        api_key: str,
+        target_language: str,
+        *,
+        model: str = "gpt-3.5-turbo",
+        openai_client: Optional[Any] = None,
+    ) -> None:
+        """Create a provider instance.
+
+        Parameters
+        ----------
+        api_key:
+            OpenAI API key.
+        target_language:
+            Language into which translations should be produced.
+        model:
+            Chat completion model name. Defaults to ``gpt-3.5-turbo``.
+        openai_client:
+            Optional object compatible with the ``openai`` package.  Used to
+            facilitate testing by injecting a fake client.
+        """
+
+        if openai_client is None:
+            import openai  # type: ignore
+
+            self._openai = openai
+        else:
+            self._openai = openai_client
+
+        # ``api_key`` might be ``None`` – the real OpenAI library will raise an
+        # exception when used without a key.  We simply assign it to allow tests
+        # to run without contacting the network.
+        self._openai.api_key = api_key
+
+        self.target_language = target_language
+        self.model = model
+
+        prompts_dir = os.path.join(os.path.dirname(__file__), "..", "prompts")
+        self._system_template = self._load_template(prompts_dir, "vocab.system.md")
+        self._assistant_template = self._load_template(
+            prompts_dir, "vocab.assistant.md"
+        )
+        self._user_template = self._load_template(prompts_dir, "vocab.user.md")
+
+    @staticmethod
+    def _load_template(directory: str, filename: str) -> Template:
+        path = os.path.join(directory, filename)
+        with open(path, encoding="utf-8") as fh:
+            return Template(fh.read())
+
+    def get_vocab(self, term: str, context: str = "") -> Dict[str, str]:
+        """Return vocabulary information for ``term``.
+
+        The returned dictionary contains ``term``, ``term_translation``,
+        ``sentence`` and ``sentence_translation`` keys as produced by the chat
+        completion model.
+        """
+
+        system_msg = self._system_template.substitute(
+            target_language=self.target_language
+        )
+        assistant_msg = self._assistant_template.template
+        user_msg = self._user_template.substitute(
+            term=term, target_language=self.target_language, context=context
+        )
+
+        response = self._openai.ChatCompletion.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": system_msg},
+                {"role": "assistant", "content": assistant_msg},
+                {"role": "user", "content": user_msg},
+            ],
+            temperature=0.7,
+        )
+
+        # ``openai`` library returns a complex object; we only need the text
+        # content of the first choice.
+        content = response.choices[0].message.content  # type: ignore[index]
+        return json.loads(content)

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -9,6 +9,7 @@ from aqt import mw
 from aqt.qt import QAction
 from .view import get_card_input_dialog, show_info, show_warning
 from core.german_card import GermanCard
+from core.vocab_provider import VocabProvider
 from .anki_service import AnkiService
 
 def generate_card():
@@ -16,9 +17,13 @@ def generate_card():
     if not result:
         return
    
-    # TODO: create vocab provider and pass it to the card.
+    api_key = os.environ.get("OPENAI_API_KEY")
+    target_language = os.environ.get("TARGET_LANGUAGE", "English")
+    vocab_provider = VocabProvider(api_key, target_language)
 
-    card = GermanCard.create_from_user_input(result.term, result.audio_path)
+    card = GermanCard.create_from_user_input(
+        result.term, "", result.audio_path, vocab_provider
+    )
     if not card.is_valid():
         show_warning("Invalid card data.")
         return

--- a/tests/test_german_card.py
+++ b/tests/test_german_card.py
@@ -4,6 +4,16 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from core.german_card import GermanCard
 
+
+class DummyProvider:
+    def get_vocab(self, term, context=""):
+        return {
+            "term": term,
+            "term_translation": f"{term}_t",
+            "sentence": f"S {term}",
+            "sentence_translation": f"ST {term}",
+        }
+
 def test_german_card_creation():
     card = GermanCard(
         term="Haus",
@@ -69,12 +79,14 @@ def test_gen_id():
         assert card._id == expected_id, f"Failed for term: '{term}', expected: '{expected_id}', got: '{card._id}'"
 
 def test_create_from_user_input():
-    card = GermanCard.create_from_user_input("Hund", "bark.mp3")
+    card = GermanCard.create_from_user_input(
+        "Hund", "", "bark.mp3", DummyProvider()
+    )
     assert card.term == "Hund"
-    assert card.context == "Example context for Hund"
-    assert card.sentence == "Example sentence with Hund"
-    assert card.term_translation == "Translation of Hund"
-    assert card.sentence_translation == "Translation of example sentence with Hund"
+    assert card.context == ""
+    assert card.sentence == "S Hund"
+    assert card.term_translation == "Hund_t"
+    assert card.sentence_translation == "ST Hund"
 
 if __name__ == "__main__":
     test_german_card_creation()

--- a/tests/test_vocab_provider.py
+++ b/tests/test_vocab_provider.py
@@ -1,0 +1,48 @@
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from core.vocab_provider import VocabProvider
+
+
+class FakeChatCompletion:
+    def __init__(self, content):
+        self.content = content
+        self.last_args = None
+
+    def create(self, model, messages, temperature):
+        self.last_args = {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+        }
+        # Simulate OpenAI response object structure
+        class _Message:
+            def __init__(self, c):
+                self.content = c
+        class _Choice:
+            def __init__(self, c):
+                self.message = _Message(c)
+        class _Response:
+            def __init__(self, c):
+                self.choices = [_Choice(c)]
+        return _Response(self.content)
+
+
+class FakeOpenAI:
+    def __init__(self, content):
+        self.ChatCompletion = FakeChatCompletion(content)
+        self.api_key = None
+
+
+def test_get_vocab():
+    json_resp = '{"term":"der Hund","term_translation":"dog","sentence":"Der Hund bellt.","sentence_translation":"The dog barks."}'
+    fake_client = FakeOpenAI(json_resp)
+    provider = VocabProvider("test", "English", openai_client=fake_client)
+    data = provider.get_vocab("Hund", "")
+
+    assert data["term"] == "der Hund"
+    assert fake_client.ChatCompletion.last_args is not None
+    system_msg = fake_client.ChatCompletion.last_args["messages"][0]["content"]
+    assert "English" in system_msg
+


### PR DESCRIPTION
## Summary
- implement `VocabProvider` with OpenAI ChatGPT integration
- update `GermanCard.create_from_user_input` to use vocab provider
- configure Anki plugin to initialise vocab provider and pass it to the card
- expand GermanCard tests and add provider tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686637d501ec8327bea237b3f4609899