### PR TITLE
Implement abstract vocab provider

### DIFF
--- a/core/german_card.py
+++ b/core/german_card.py
@@ -1,4 +1,5 @@
 from .audio_card import AudioCard
+from .vocab_provider import VocabProvider
 import re
 
 class GermanCard(AudioCard):
@@ -88,11 +89,19 @@ class GermanCard(AudioCard):
         ]
 
     @classmethod
-    def create_from_user_input(cls, term, context, audio_path, vocab_provider):
-        # TODO: use vocab provider to generate card
+    def create_from_user_input(
+        cls,
+        term: str,
+        context: str,
+        audio_path: str,
+        vocab_provider: VocabProvider,
+    ):
+        """Create a card using vocabulary data from ``vocab_provider``."""
 
-        card = cls(term, f"Example context for {term}", audio_path)
-        card.sentence = f"Example sentence with {term}"
-        card.term_translation = f"Translation of {term}"
-        card.sentence_translation = f"Translation of example sentence with {term}"
+        data = vocab_provider.get_vocab(term, context)
+
+        card = cls(data.term, context, audio_path)
+        card.sentence = data.sentence
+        card.term_translation = data.term_translation
+        card.sentence_translation = data.sentence_translation
         return card

--- a/core/openai_vocab_provider.py
+++ b/core/openai_vocab_provider.py
@@ -1,0 +1,78 @@
+"""OpenAI-based implementation of the :class:`VocabProvider` interface."""
+
+from __future__ import annotations
+
+from string import Template
+from typing import Any, Optional
+import json
+import os
+
+from .vocab_provider import VocabProvider, VocabItem
+
+
+class OpenaiVocabProvider(VocabProvider):
+    """Retrieve vocabulary data using OpenAI chat completion."""
+
+    def __init__(
+        self,
+        api_key: str,
+        target_language: str,
+        *,
+        model: str = "gpt-3.5-turbo",
+        openai_client: Optional[Any] = None,
+    ) -> None:
+        if openai_client is None:
+            import openai  # type: ignore
+
+            self._openai = openai
+        else:
+            self._openai = openai_client
+
+        # ``api_key`` might be ``None`` – the real OpenAI library will raise an
+        # exception when used without a key.  We simply assign it to allow tests
+        # to run without contacting the network.
+        self._openai.api_key = api_key
+
+        self.target_language = target_language
+        self.model = model
+
+        prompts_dir = os.path.join(os.path.dirname(__file__), "..", "prompts")
+        self._system_template = self._load_template(prompts_dir, "vocab.system.md")
+        self._assistant_template = self._load_template(
+            prompts_dir, "vocab.assistant.md"
+        )
+        self._user_template = self._load_template(prompts_dir, "vocab.user.md")
+
+    @staticmethod
+    def _load_template(directory: str, filename: str) -> Template:
+        path = os.path.join(directory, filename)
+        with open(path, encoding="utf-8") as fh:
+            return Template(fh.read())
+
+    def get_vocab(self, term: str, context: str = "") -> VocabItem:
+        system_msg = self._system_template.substitute(
+            target_language=self.target_language
+        )
+        assistant_msg = self._assistant_template.template
+        user_msg = self._user_template.substitute(
+            term=term, target_language=self.target_language, context=context
+        )
+
+        response = self._openai.ChatCompletion.create(
+            model=self.model,
+            messages=[
+                {"role": "system", "content": system_msg},
+                {"role": "assistant", "content": assistant_msg},
+                {"role": "user", "content": user_msg},
+            ],
+            temperature=0.7,
+        )
+
+        content = response.choices[0].message.content  # type: ignore[index]
+        data = json.loads(content)
+        return VocabItem(
+            term=data.get("term", term),
+            term_translation=data.get("term_translation", ""),
+            sentence=data.get("sentence", ""),
+            sentence_translation=data.get("sentence_translation", ""),
+        )

--- a/core/vocab_provider.py
+++ b/core/vocab_provider.py
@@ -1,3 +1,28 @@
-# TODO: open AI integration goes here
-# TODO: use ../prompts/*
-# TODO: init with openai api key and target language
+"""Vocabulary provider abstractions and OpenAI implementation."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+
+
+@dataclass
+class VocabItem:
+    """Simple container for vocabulary information."""
+
+    term: str = ""
+    term_translation: str = ""
+    sentence: str = ""
+    sentence_translation: str = ""
+
+
+class VocabProvider(ABC):
+    """Abstract base class for vocabulary providers."""
+
+    @abstractmethod
+    def get_vocab(self, term: str, context: str = "") -> VocabItem:
+        """Return :class:`VocabItem` for the given term."""
+        raise NotImplementedError
+
+

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -9,20 +9,25 @@ from aqt import mw
 from aqt.qt import QAction
 from .view import get_card_input_dialog, show_info, show_warning
 from core.german_card import GermanCard
+from core.openai_vocab_provider import OpenaiVocabProvider
 from .anki_service import AnkiService
 
 def generate_card():
     result = get_card_input_dialog(mw)
     if not result:
         return
-   
-    # TODO: create vocab provider and pass it to the card.
 
-    card = GermanCard.create_from_user_input(result.term, result.audio_path)
+    api_key = os.environ.get("OPENAI_API_KEY")
+    target_language = os.environ.get("TARGET_LANGUAGE", "English")
+    vocab_provider = OpenaiVocabProvider(api_key, target_language)
+
+    card = GermanCard.create_from_user_input(
+        result.term, "", result.audio_path, vocab_provider
+    )
     if not card.is_valid():
         show_warning("Invalid card data.")
         return
-    
+
     anki_service = AnkiService(mw)
     try:
         anki_service.save_card(card, result.selected_deck_id)
@@ -32,4 +37,4 @@ def generate_card():
 
 action = QAction("German Card", mw)
 action.triggered.connect(generate_card)
-mw.form.menuTools.addAction(action) 
+mw.form.menuTools.addAction(action)

--- a/plugin/anki_service.py
+++ b/plugin/anki_service.py
@@ -60,4 +60,4 @@ class AnkiService:
         self.mw.col.add_note(note, deck_id)
         self.mw.col.save()
         self._copy_audio_to_media(card)
-        return note 
+        return note

--- a/plugin/view.py
+++ b/plugin/view.py
@@ -73,4 +73,4 @@ def show_info(message):
 
 def show_warning(message):
     from aqt.utils import showWarning
-    showWarning(message) 
+    showWarning(message)

--- a/tests/test_german_card.py
+++ b/tests/test_german_card.py
@@ -3,6 +3,17 @@ import os
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 
 from core.german_card import GermanCard
+from core.vocab_provider import VocabProvider, VocabItem
+
+
+class DummyProvider(VocabProvider):
+    def get_vocab(self, term, context: str = "") -> VocabItem:
+        return VocabItem(
+            term=term,
+            term_translation=f"{term}_t",
+            sentence=f"S {term}",
+            sentence_translation=f"ST {term}",
+        )
 
 def test_german_card_creation():
     card = GermanCard(
@@ -10,7 +21,7 @@ def test_german_card_creation():
         context="Das Haus ist groß.",
         audio_path="test.mp3"
     )
-    
+
     assert card.term == "Haus"
     assert card.context == "Das Haus ist groß."
     assert card._audio_filename == "[sound:test.mp3]"
@@ -26,58 +37,60 @@ def test_gen_id():
         # Basic words
         ("Haus", "haus"),
         ("Auto", "auto"),
-        
+
         # Words with spaces
         ("Das Haus", "das_haus"),
         ("Ein schönes Auto", "ein_schoenes_auto"),
-        
+
         # German umlauts
         ("Mädchen", "maedchen"),
         ("König", "koenig"),
         ("Bücher", "buecher"),
         ("Straße", "strasse"),
-        
+
         # Special characters
         ("Haus!", "haus"),
         ("Auto@#$%", "auto"),
         ("Test-Wort", "testwort"),
         ("Wort123", "wort123"),
-        
+
         # Mixed case
         ("HAUS", "haus"),
         ("HaUs", "haus"),
-        
+
         # Numbers
         ("Auto2023", "auto2023"),
         ("123Haus", "123haus"),
-        
+
         # Complex examples
         ("Schlüssel", "schluessel"),
         ("Müller", "mueller"),
         ("Königsberg", "koenigsberg"),
         ("Größe", "groesse"),
-        
+
         # Edge cases
         ("", ""),
         ("!@#$%^&*()", ""),
         ("   ", "___"),
         ("test_word", "test_word"),
     ]
-    
+
     for term, expected_id in test_cases:
         card = GermanCard(term=term, context="Test", audio_path="")
         assert card._id == expected_id, f"Failed for term: '{term}', expected: '{expected_id}', got: '{card._id}'"
 
 def test_create_from_user_input():
-    card = GermanCard.create_from_user_input("Hund", "bark.mp3")
+    card = GermanCard.create_from_user_input(
+        "Hund", "", "bark.mp3", DummyProvider()
+    )
     assert card.term == "Hund"
-    assert card.context == "Example context for Hund"
-    assert card.sentence == "Example sentence with Hund"
-    assert card.term_translation == "Translation of Hund"
-    assert card.sentence_translation == "Translation of example sentence with Hund"
+    assert card.context == ""
+    assert card.sentence == "S Hund"
+    assert card.term_translation == "Hund_t"
+    assert card.sentence_translation == "ST Hund"
 
 if __name__ == "__main__":
     test_german_card_creation()
     test_german_card_invalid()
     test_gen_id()
-    print("All tests passed!") 
+    print("All tests passed!")

--- a/tests/test_vocab_provider.py
+++ b/tests/test_vocab_provider.py
@@ -1,0 +1,50 @@
+import sys
+import os
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+
+from core.openai_vocab_provider import OpenaiVocabProvider
+from core.vocab_provider import VocabItem
+
+
+class FakeChatCompletion:
+    def __init__(self, content):
+        self.content = content
+        self.last_args = None
+
+    def create(self, model, messages, temperature):
+        self.last_args = {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+        }
+        # Simulate OpenAI response object structure
+        class _Message:
+            def __init__(self, c):
+                self.content = c
+        class _Choice:
+            def __init__(self, c):
+                self.message = _Message(c)
+        class _Response:
+            def __init__(self, c):
+                self.choices = [_Choice(c)]
+        return _Response(self.content)
+
+
+class FakeOpenAI:
+    def __init__(self, content):
+        self.ChatCompletion = FakeChatCompletion(content)
+        self.api_key = None
+
+
+def test_get_vocab():
+    json_resp = '{"term":"der Hund","term_translation":"dog","sentence":"Der Hund bellt.","sentence_translation":"The dog barks."}'
+    fake_client = FakeOpenAI(json_resp)
+    provider = OpenaiVocabProvider("test", "English", openai_client=fake_client)
+    data = provider.get_vocab("Hund", "")
+
+    assert isinstance(data, VocabItem)
+    assert data.term == "der Hund"
+    assert fake_client.ChatCompletion.last_args is not None
+    system_msg = fake_client.ChatCompletion.last_args["messages"][0]["content"]
+    assert "English" in system_msg
+


### PR DESCRIPTION
## Summary
- refactor vocab provider into abstract interface
- implement `OpenaiVocabProvider` returning a dataclass
- adjust plugin and GermanCard to use new provider
- update unit tests for provider and GermanCard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686637d501ec8327bea237b3f4609899