### PR TITLE
Remove unused audio file path support

### DIFF
--- a/core/audio_card.py
+++ b/core/audio_card.py
@@ -23,12 +23,8 @@ class AudioCard(ABC):
         pass
 
     @abstractmethod
-    def get_audio_path(self) -> str:
-        pass
-
-    @abstractmethod
     def to_fields_list(self) -> list:
-        pass 
+        pass
 
     @abstractmethod
     def get_audio_data(self) -> Optional[bytes]:

--- a/core/german_card.py
+++ b/core/german_card.py
@@ -9,15 +9,12 @@ class GermanCard(AudioCard):
         self,
         term: str,
         context: str,
-        audio_path: str
     ):
         self._id = self._gen_id(term)
         self.term = term
         self.context = context
-        self.audio_path = audio_path
-        self._audio_filename = self._gen_audio_filename(audio_path)
         self._audio_data = None
-        self._audio_filename2 = ""
+        self._audio_filename = ""
         self.sentence = ""
         self.term_translation = ""
         self.sentence_translation = ""
@@ -38,15 +35,6 @@ class GermanCard(AudioCard):
         
         # Remove any remaining special characters and keep only alphanumeric and underscores
         return re.sub(r'[^a-z0-9_]', '', id_base)
-
-    def _gen_audio_filename(self, audio_path: str) -> str:
-        if audio_path:
-            import os
-            filename = os.path.basename(audio_path)
-            audio_filename = f"[sound:{filename}]"
-        else:
-            audio_filename = ""
-        return audio_filename
 
     def is_valid(self):
         return bool(self._id)
@@ -78,14 +66,11 @@ class GermanCard(AudioCard):
 <div class="context">{{context}}</div>
 """
 
-    def get_audio_path(self) -> str:
-        return self.audio_path
-
     def to_fields_list(self) -> list:
-        if self._audio_filename2:
-            audio_field = f"[sound:{self._audio_filename2}]"
+        if self._audio_filename:
+            audio_field = f"[sound:{self._audio_filename}]"
         else:
-            audio_field = self._audio_filename
+            audio_field = ""
 
         return [
             self._id,
@@ -101,21 +86,20 @@ class GermanCard(AudioCard):
         return self._audio_data
 
     def get_audio_filename(self) -> str:
-        return self._audio_filename2
+        return self._audio_filename
 
     @classmethod
     def create_from_user_input(
         cls,
         term: str,
         context: str,
-        audio_path: str,
         vocab_provider: VocabProvider,
         audio_provider: Optional[AudioProvider] = None,
     ):
         """Create a card using vocabulary data from ``vocab_provider``."""
 
         data = vocab_provider.get_vocab(term, context)
-        card = cls(data.term, context, audio_path)
+        card = cls(data.term, context)
         card.sentence = data.sentence
         card.term_translation = data.term_translation
         card.sentence_translation = data.sentence_translation
@@ -124,6 +108,7 @@ class GermanCard(AudioCard):
             card._audio_data = None
         else:
             card._audio_data = audio_provider.get_audio(card.sentence)
-            card._audio_filename2 = audio_provider.get_file_name(card._id)
+            card._audio_filename = audio_provider.get_file_name(card._id)
 
         return card
+

--- a/plugin/__init__.py
+++ b/plugin/__init__.py
@@ -48,7 +48,7 @@ def generate_card():
     audio_provider = GttsAudioProvider("de")
 
     card = GermanCard.create_from_user_input(
-        result.term, "", result.audio_path, vocab_provider, audio_provider
+        result.term, "", vocab_provider, audio_provider
     )
     if not card.is_valid():
         show_warning("Invalid card data.")

--- a/plugin/anki_service.py
+++ b/plugin/anki_service.py
@@ -48,20 +48,10 @@ class AnkiService:
         Returns the filename used in the media directory, or None if no audio or copy failed.
         """
         audio_data = card.get_audio_data()
-        if audio_data is not None:
-            return self._save_audio_data_to_media(audio_data, card.get_audio_filename())
+        if audio_data is None:
+            return None
 
-        audio_path = card.get_audio_path()
-        if not audio_path or not os.path.exists(audio_path):
-            return None
-        filename = os.path.basename(audio_path)
-        media_dir = self.mw.col.media.dir()
-        destination = os.path.join(media_dir, filename)
-        try:
-            shutil.copy2(audio_path, destination)
-            return filename
-        except Exception:
-            return None
+        return self._save_audio_data_to_media(audio_data, card.get_audio_filename())
 
     def save_card(self, card: AudioCard, deck_id):
         """

--- a/plugin/view.py
+++ b/plugin/view.py
@@ -9,10 +9,9 @@ from aqt.qt import (
 )
 
 class CardInputResult:
-    def __init__(self, term, selected_deck_id, audio_path):
+    def __init__(self, term, selected_deck_id):
         self.term = term
         self.selected_deck_id = selected_deck_id
-        self.audio_path = audio_path
 
 
 def get_api_settings_dialog(mw, api_key: str, target_language: str):
@@ -81,12 +80,6 @@ def get_card_input_dialog(mw):
     layout.addWidget(deck_label)
     layout.addWidget(deck_combo)
 
-    # Audio file path input
-    audio_label = QLabel("Audio file path (optional):")
-    audio_input = QLineEdit()
-    audio_input.setPlaceholderText("e.g., /path/to/audio.mp3")
-    layout.addWidget(audio_label)
-    layout.addWidget(audio_input)
 
     # Buttons
     button_layout = QHBoxLayout()
@@ -105,8 +98,7 @@ def get_card_input_dialog(mw):
 
     term = term_input.text().strip()
     selected_deck_id = deck_combo.currentData()
-    audio_path = audio_input.text().strip()
-    return CardInputResult(term, selected_deck_id, audio_path)
+    return CardInputResult(term, selected_deck_id)
 
 def show_info(message):
     from aqt.utils import showInfo

--- a/tests/test_core_integration.py
+++ b/tests/test_core_integration.py
@@ -44,7 +44,6 @@ def test_german_card_openai_integration():
     # Test parameters
     test_term = "Haus"
     test_context = "A1 level German"
-    test_audio_path = "test_audio.mp3"
     
     try:
         # Create real OpenAI vocab provider with explicit OpenAI client
@@ -58,7 +57,6 @@ def test_german_card_openai_integration():
         card = GermanCard.create_from_user_input(
             term=test_term,
             context=test_context,
-            audio_path=test_audio_path,
             vocab_provider=vocab_provider
         )
         
@@ -92,7 +90,6 @@ def test_gtts_audio_provider_integration():
     card = GermanCard.create_from_user_input(
         term="Haus",
         context="",
-        audio_path="",
         vocab_provider=DummyProvider(),
         audio_provider=GttsAudioProvider("de", gtts_factory=gTTS),
     )

--- a/tests/test_german_card.py
+++ b/tests/test_german_card.py
@@ -18,17 +18,16 @@ class DummyProvider(VocabProvider):
 def test_german_card_creation():
     card = GermanCard(
         term="Haus",
-        context="Das Haus ist groß.",
-        audio_path="test.mp3"
+        context="Das Haus ist groß."
     )
 
     assert card.term == "Haus"
     assert card.context == "Das Haus ist groß."
-    assert card._audio_filename == "[sound:test.mp3]"
+    assert card.get_audio_filename() == ""
     assert card.is_valid() == True
 
 def test_german_card_invalid():
-    card = GermanCard(term="", context="Test", audio_path="")
+    card = GermanCard(term="", context="Test")
     assert card.is_valid() == False
 
 def test_gen_id():
@@ -76,12 +75,12 @@ def test_gen_id():
     ]
 
     for term, expected_id in test_cases:
-        card = GermanCard(term=term, context="Test", audio_path="")
+        card = GermanCard(term=term, context="Test")
         assert card._id == expected_id, f"Failed for term: '{term}', expected: '{expected_id}', got: '{card._id}'"
 
 def test_create_from_user_input():
     card = GermanCard.create_from_user_input(
-        "Hund", "", "bark.mp3", DummyProvider()
+        "Hund", "", DummyProvider()
     )
     assert card.term == "Hund"
     assert card.context == ""


### PR DESCRIPTION
## Summary
- drop AudioCard.get_audio_path and associated logic
- simplify GermanCard initialization
- remove audio path UI from the view dialog
- copy only generated audio in AnkiService
- update tests for new API

## Testing
- `python3 -m pytest -q` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_686940bb88b483279bc4aa49761aeda7